### PR TITLE
Depend on Ubuntu's nm captive portal config

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Vcs-Browser: http://bazaar.launchpad.net/~elementary-apps/capnet-assist/trunk/fi
 
 Package: capnet-assist
 Architecture: any
-Depends: network-manager, ${misc:Depends}, ${shlibs:Depends}
+Depends: network-manager, network-manager-config-connectivity-ubuntu, ${misc:Depends}, ${shlibs:Depends}
 Description: Captive login detector
  A small WebKit app only to make a user log in when a
  captive portal is detected.


### PR DESCRIPTION
Fixes https://github.com/elementary/os/issues/25 and unblocks https://github.com/elementary/capnet-assist/pull/23