### PR TITLE
use new symbolic security icons

### DIFF
--- a/src/CertButton.vala
+++ b/src/CertButton.vala
@@ -45,17 +45,17 @@ public class CertButton : Gtk.ToggleButton {
                     tooltip = _("Loading captive portal.");
                     break;
                 case Security.NONE:
-                    icon = new ThemedIcon.from_names ({"channel-insecure-symbolic", "security-low"});
+                    icon = new ThemedIcon ("security-low-symbolic");
                     tooltip = _("The page is served over an unprotected connection.");
                     break;
 
                 case Security.SECURE:
-                    icon = new ThemedIcon.from_names ({"channel-secure-symbolic", "security-high"});
+                    icon = new ThemedIcon ("security-high-symbolic");
                     tooltip = _("The page is served over a protected connection.");
                     break;
 
                 case Security.MIXED_CONTENT:
-                    icon = new ThemedIcon.from_names ({"channel-insecure-symbolic", "security-low"});
+                    icon = new ThemedIcon ("security-medium-symbolic");
                     tooltip = _("Some elements of this page are served over an unprotected connection.");
                     break;
 


### PR DESCRIPTION
![screenshot from 2018-01-28 22 53 07](https://user-images.githubusercontent.com/7277719/35497429-f97af222-047e-11e8-9e6f-bb625e758349.png)
