### PR TITLE
Docs: Add missing 'cd build' instruction to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ You'll need the following dependencies:
 Run `meson` to configure the build environment and then `ninja test` to build and run automated tests
 
     meson build --prefix=/usr
+    cd build
     ninja test
     
 To install, use `ninja install`, then execute with `captive-login`


### PR DESCRIPTION
Hey, I wanted to test out some build related things for elementary OS and noticed, that there's an instruction (`cd build`) missing in the readme, which without the `ninja test` command obiously fails because the working directory is wrong.

Without fix:
![image](https://user-images.githubusercontent.com/10424668/193396739-1a664f92-e713-4ff5-8551-14c287c963c4.png)

With fix:
![image](https://user-images.githubusercontent.com/10424668/193396837-c55ef78c-73a8-4be4-a72f-683d1900ed8c.png)

