### PR TITLE
CertButton: rewrite without gcr-ui

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,6 @@ executable(
     'src/TabbedWebView.vala',
     dependencies: [
         dependency('gcr-3'),
-        dependency('gcr-ui-3'),
         dependency('gio-2.0'),
         dependency('glib-2.0'),
         dependency('gobject-2.0'),

--- a/src/CertButton.vala
+++ b/src/CertButton.vala
@@ -1,24 +1,11 @@
 /*
-* Copyright (c) 2016-2017 elementary LLC (http://launchpad.net/capnet-assist)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA.
-*
-*/
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ * SPDX-FileCopyrightText: 2016-2023 elementary, Inc. (https://elementary.io)
+ */
 
-public class CertButton : Gtk.ToggleButton {
+public class CertButton : Gtk.MenuButton {
+    public CaptiveLogin captive_login_window { get; construct set; }
+
     public enum Security {
         NONE,
         SECURE,
@@ -26,8 +13,7 @@ public class CertButton : Gtk.ToggleButton {
         MIXED_CONTENT,
     }
 
-    private Security _security;
-
+    private Security _security = LOADING;
     public Security security {
         get {
             return _security;
@@ -35,51 +21,112 @@ public class CertButton : Gtk.ToggleButton {
         set {
             _security = value;
 
-            Icon icon;
-            string tooltip;
+            var uri = captive_login_window.get_uri ();
 
             switch (value) {
-                case Security.LOADING:
-                    icon = new ThemedIcon ("content-loading-symbolic");
-                    tooltip = _("Loading captive portal.");
-                    break;
-                case Security.NONE:
-                    icon = new ThemedIcon ("security-low-symbolic");
-                    tooltip = _("The page is served over an unprotected connection.");
+                case LOADING:
+                    icon_name = "content-loading-symbolic";
+                    tooltip_text = _("Loading captive portal.");
                     break;
 
-                case Security.SECURE:
-                    icon = new ThemedIcon ("security-high-symbolic");
-                    tooltip = _("The page is served over a protected connection.");
+                case NONE:
+                    icon_name = "security-low-symbolic";
+                    tooltip_text = _("“%s” is served over an unprotected connection").printf (uri);
                     break;
 
-                case Security.MIXED_CONTENT:
-                    icon = new ThemedIcon ("security-medium-symbolic");
-                    tooltip = _("Some elements of this page are served over an unprotected connection.");
+                case SECURE:
+                    icon_name = "security-high-symbolic";
+                    tooltip_text = _("“%s” is served over a protected connection").printf (uri);
                     break;
 
-                default:
-                    assert_not_reached ();
+                case MIXED_CONTENT:
+                    icon_name = "security-medium-symbolic";
+                    tooltip_text = _("Some elements of “%s” are served over an unprotected connection").printf (uri);
+                    break;
             }
 
-            image = new Gtk.Image.from_gicon (icon, Gtk.IconSize.BUTTON);
-            tooltip_text = tooltip;
-            set_sensitive (value != CertButton.Security.NONE && value != CertButton.Security.LOADING);
+            popover_label.label = tooltip_text;
+
+            if (security == SECURE) {
+                popover_label.get_style_context ().remove_class (Gtk.STYLE_CLASS_WARNING);
+                popover_label.get_style_context ().add_class ("success");
+            } else {
+                popover_label.get_style_context ().remove_class ("success");
+                popover_label.get_style_context ().add_class (Gtk.STYLE_CLASS_WARNING);
+            }
+
+            popover_image.icon_name = icon_name.replace ("-symbolic", "");
+
+            image = new Gtk.Image.from_icon_name (icon_name, BUTTON);
+            sensitive = value != CertButton.Security.NONE && value != CertButton.Security.LOADING;
         }
     }
 
-    public CaptiveLogin captive_login_window {
-        get; set construct;
-    }
+    private Granite.HeaderLabel cert_subject;
+    private Gtk.Image popover_image;
+    private Gtk.Label cert_expiry;
+    private Gtk.Label cert_issuer;
+    private Gtk.Label popover_label;
+    private string icon_name = "content-loading-symbolic";
 
     public CertButton (CaptiveLogin captive_login_window) {
-        Object (security: Security.LOADING, captive_login_window: captive_login_window);
+        Object (captive_login_window: captive_login_window);
     }
 
     construct {
         var style_context = get_style_context ();
         style_context.add_class (Gtk.STYLE_CLASS_FLAT);
         style_context.add_class ("titlebutton");
+
+        popover_image = new Gtk.Image () {
+            pixel_size = 48,
+            valign = START
+        };
+
+        popover_label = new Gtk.Label ("") {
+            xalign = 0,
+            max_width_chars = 55,
+            wrap = true,
+            wrap_mode = WORD_CHAR
+        };
+        popover_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
+
+        cert_subject = new Granite.HeaderLabel ("");
+
+        cert_issuer = new Gtk.Label ("") {
+            halign = START,
+            margin_start = 12
+        };
+
+        cert_expiry = new Gtk.Label ("") {
+            halign = START,
+            margin_start = 12,
+            margin_bottom = 6
+        };
+
+        var cert_box = new Gtk.Box (VERTICAL, 3);
+        cert_box.get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
+        cert_box.add (cert_subject);
+        cert_box.add (cert_issuer);
+        cert_box.add (cert_expiry);
+
+        var frame = new Gtk.Frame (null) {
+            child = cert_box,
+            margin_top = 12
+        };
+
+        var grid = new Gtk.Grid () {
+            column_spacing = 12,
+            margin = 12
+        };
+        grid.attach (popover_image, 0, 0, 1, 2);
+        grid.attach (popover_label, 1, 0);
+        grid.attach (frame, 1, 1);
+        grid.show_all ();
+
+        popover = new Gtk.Popover (this) {
+            child = grid
+        };
 
         toggled.connect (on_tls_button_click);
     }
@@ -88,97 +135,26 @@ public class CertButton : Gtk.ToggleButton {
         TlsCertificate cert;
         TlsCertificateFlags cert_flags;
 
-        if (!get_active ()) {
+        if (!active) {
             return;
         }
 
         if (!captive_login_window.get_tls_info (out cert, out cert_flags)) {
-            set_active (false);
+            active = false;
             return;
         }
 
-        var popover = new Gtk.Popover (this);
-        popover.border_width = 12;
-
-        // Wonderful hack we got here, the vapi for Gtk has a wrong definition
-        // for the get_gicon () method, it's not reported as an out parameter
-        // hence we're stuck with passing everything by value.
-        // Since we're badass we pass the INVALID constant that evaluates to 0
-        // which is casted into a NULL pointer and allows us to save the date.
-        Icon button_icon;
-#if VALA_0_30
-        ((Gtk.Image) get_image ()).get_gicon (out button_icon, null);
-#else
-        ((Gtk.Image) get_image ()).get_gicon (out button_icon, Gtk.IconSize.INVALID);
-#endif
-
-        var icon = new Gtk.Image.from_gicon (button_icon, Gtk.IconSize.DIALOG);
-        icon.valign = Gtk.Align.START;
-
-        var primary_text = new Gtk.Label (captive_login_window.get_uri ());
-        primary_text.get_style_context ().add_class ("h3");
-        primary_text.halign = Gtk.Align.START;
-        primary_text.margin_start = 9;
-        primary_text.max_width_chars = 70;
-        primary_text.wrap = true;
-        primary_text.wrap_mode = Pango.WrapMode.WORD_CHAR;
-
-        var secondary_text = new Gtk.Label (get_tooltip_text ());
-        secondary_text.halign = Gtk.Align.START;
-        secondary_text.margin_start = 9;
-
-        if (security == CertButton.Security.SECURE) {
-            icon.get_style_context ().add_class ("success");
-            secondary_text.get_style_context ().add_class ("success");
-        } else {
-            icon.get_style_context ().add_class ("warning");
-            secondary_text.get_style_context ().add_class ("warning");
-        }
-
         var gcr_cert = new Gcr.SimpleCertificate (cert.certificate.data);
-        var cert_details = new Gcr.CertificateWidget (gcr_cert);
 
-        var grid = new Gtk.Grid ();
-        grid.column_spacing = 3;
-        grid.attach (icon, 0, 0, 1, 2);
-        grid.attach (primary_text, 1, 0, 1, 1);
-        grid.attach (secondary_text, 1, 1, 1, 1);
-        grid.attach (cert_details, 1, 2, 1, 1);
+        Time time;
+        gcr_cert.expiry.to_time (out time);
 
-        popover.add (grid);
+        cert_expiry.label = _("Expires %s").printf (
+            time.format (Granite.DateTime.get_default_date_format (false, true, true))
+        );
 
-        // This hack has been borrowed from midori, the widget provided by the
-        // GCR library would fail with an assertion when the 'details' button was
-        // clicked
-        popover.button_press_event.connect ((event) => {
-            return true;
-        });
+        cert_issuer.label = _("Issued by “%s”").printf (gcr_cert.issuer);
 
-        popover.button_release_event.connect ((event) => {
-            var child = popover.get_child ();
-            var event_widget = Gtk.get_event_widget (event);
-
-            if (child != null && event.window == popover.get_window ()) {
-                Gtk.Allocation child_alloc;
-                popover.get_allocation (out child_alloc);
-
-                if (event.x < child_alloc.x ||
-                    event.x > child_alloc.x + child_alloc.width ||
-                    event.y < child_alloc.y ||
-                    event.y > child_alloc.y + child_alloc.height) {
-                    popover.hide ();
-                    set_active (false);
-                }
-            } else if (event_widget != null && !event_widget.is_ancestor (popover)) {
-                popover.hide ();
-                set_active (false);
-            }
-
-            return true;
-        });
-
-        popover.show_all ();
-
-        return;
+        cert_subject.label = gcr_cert.subject;
     }
 }


### PR DESCRIPTION
Required for GTK 4

![Screenshot from 2023-10-10 10 37 42](https://github.com/elementary/capnet-assist/assets/7277719/e2beb08b-69ab-48e0-bada-f854d017e786)

* Rewrite without using gcr-ui. This shows only what would've been shown without the expanded details. More can be added if needed, but I'm not sure it's worth doing the whole expanded cert UI like epiphany for capnet
* Don't rebuild the entire UI when the page changes, just the parts that changed
* Use Gtk.MenuButton
* Code style