### PR TITLE
meson: Fix deprecation warnings

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -23,14 +23,14 @@ i18n.merge_file(
     output: meson.project_name() + '.desktop',
     install: true,
     install_dir: join_paths(get_option('datadir'), 'applications'),
-    po_dir: join_paths(meson.source_root(), 'po', 'extra'),
+    po_dir: join_paths(meson.project_source_root(), 'po', 'extra'),
     type: 'desktop'
 )
 
 i18n.merge_file(
     input: 'capnet-assist.metainfo.xml.in',
     output: meson.project_name() + '.metainfo.xml',
-    po_dir: meson.source_root() / 'po' / 'extra',
+    po_dir: meson.project_source_root() / 'po' / 'extra',
     type: 'xml',
     install: true,
     install_dir: get_option('datadir') / 'metainfo',

--- a/po/extra/meson.build
+++ b/po/extra/meson.build
@@ -1,5 +1,5 @@
 i18n.gettext('extra',
-    args: '--directory=' + meson.source_root(),
+    args: '--directory=' + meson.project_source_root(),
     preset: 'glib',
     install: false,
 )

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,5 +1,5 @@
 i18n.gettext(meson.project_name(),
-    args: '--directory=' + meson.source_root(),
+    args: '--directory=' + meson.project_source_root(),
     preset: 'glib'
 )
 subdir('extra')


### PR DESCRIPTION
Fixes these warnings on build:

```
../data/meson.build:26: WARNING: Project targets '>= 0.57' but uses feature deprecated since '0.56.0': meson.source_root. use meson.project_source_root() or meson.global_source_root() instead.
Program msgfmt found: YES (/usr/bin/msgfmt)
../data/meson.build:33: WARNING: Project targets '>= 0.57' but uses feature deprecated since '0.56.0': meson.source_root. use meson.project_source_root() or meson.global_source_root() instead.
../po/meson.build:2: WARNING: Project targets '>= 0.57' but uses feature deprecated since '0.56.0': meson.source_root. use meson.project_source_root() or meson.global_source_root() instead.
Program msginit found: YES (/usr/bin/msginit)
Program msgmerge found: YES (/usr/bin/msgmerge)
Program xgettext found: YES (/usr/bin/xgettext)
../po/extra/meson.build:2: WARNING: Project targets '>= 0.57' but uses feature deprecated since '0.56.0': meson.source_root. use meson.project_source_root() or meson.global_source_root() instead.
Build targets in project: 409
WARNING: Deprecated features used:
 * 0.56.0: {'meson.source_root'}
```