### PR TITLE
l10n: Correct gettext package name

### DIFF
--- a/data/capnet-assist.metainfo.xml.in
+++ b/data/capnet-assist.metainfo.xml.in
@@ -2,7 +2,7 @@
 <!-- Copyright 2018-2023 elementary, Inc <contact@elementary.io> -->
 <component type="desktop-application">
   <id>io.elementary.capnet-assist</id>
-  <translation type="gettext">captive-login</translation>
+  <translation type="gettext">io.elementary.capnet-assist</translation>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <compulsory_for_desktop>Pantheon</compulsory_for_desktop>

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ project(
 gnome = import('gnome')
 i18n = import('i18n')
 
-add_global_arguments('-DGETTEXT_PACKAGE="captive-login"', '-DGCR_API_SUBJECT_TO_CHANGE', language:'c')
+add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()), '-DGCR_API_SUBJECT_TO_CHANGE', language:'c')
 
 config_data = configuration_data()
 config_data.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))


### PR DESCRIPTION
This fixes the app strings (like in the popover) is not shown as localized.

## After
![Screenshot from 2024-07-14 09-10-01](https://github.com/user-attachments/assets/03a7915a-2e4b-4e55-8767-1d600d239c9f)

## Before
![Screenshot from 2024-07-14 09-13-06](https://github.com/user-attachments/assets/fb819d7a-2b6f-43c2-a6b1-fe2c39020f4a)
