### PR TITLE
MainWindow: Fix build warnings

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -226,7 +226,7 @@ public class Captive.MainWindow : Gtk.ApplicationWindow {
                         }
                     }
                     break;
-                default;
+                default:
                     break;
             }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -206,9 +206,10 @@ public class Captive.MainWindow : Gtk.ApplicationWindow {
             switch (type) {
                 case WebKit.PolicyDecisionType.NEW_WINDOW_ACTION:
                     if (decision is WebKit.ResponsePolicyDecision) {
-                        create_tab ((decision as WebKit.ResponsePolicyDecision).request.get_uri ());
+                        var policy = (WebKit.ResponsePolicyDecision) decision;
+                        create_tab (policy.request.get_uri ());
                     }
-                break;
+                    break;
                 case WebKit.PolicyDecisionType.RESPONSE:
                     if (decision is WebKit.ResponsePolicyDecision) {
                         var policy = (WebKit.ResponsePolicyDecision) decision;
@@ -224,7 +225,9 @@ public class Captive.MainWindow : Gtk.ApplicationWindow {
                             return false;
                         }
                     }
-                break;
+                    break;
+                default;
+                    break;
             }
 
             return true;


### PR DESCRIPTION
We get the following build warnings now:

```
../src/MainWindow.vala:202.13-202.23: warning: `null' incompatible with return type `Gtk.Widget'
  202 |             return null;
      |             ^~~~~~~~~~~ 
../src/MainWindow.vala:209.37-209.87: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  209 |                         create_tab ((decision as WebKit.ResponsePolicyDecision).request.get_uri ());
      |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~             
../src/MainWindow.vala:206.13-206.25: warning: Switch does not handle `NAVIGATION_ACTION' of enum `WebKit.PolicyDecisionType'
  206 |             switch (type) {
      |             ^~~~~~~~~~~~~  
Compilation succeeded - 3 warning(s)
```

This PR fixes the second and third warnings.

- The first one: This should be fatal of vapi and can ignore because we just follows the I/F of `WebKit.WebView.create ()` as written in [Valadoc](https://valadoc.org/webkitgtk-6.0/WebKit.WebView.create.html):  
  > Returns:
  > a newly allocated WebView widget or null to propagate the event further.
- The second one: We can just cast with `()` instead of `as` which needs a null check, because it's guaranteed `decision` won't be null because of `if (decision is WebKit.ResponsePolicyDecision) {`
- The third one: Add `default` to explicitly handle `WebKit.PolicyDecisionType.NAVIGATION_ACTION`
    - Also fix indentation with our coding style while I'm here
