### PR TITLE
Control: fix maintainer field

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: capnet-assist
 Section: net
 Priority: optional
-Maintainer: elementary, Inc. <builds@elementary.io> 
+Maintainer: elementary <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1)
 Standards-Version: 4.1.1
 Homepage: https://github.com/elementary/capnet-assist


### PR DESCRIPTION
Builds on Resolute is failing due to this: https://code.launchpad.net/~elementary-os/+recipe/capnet-assist-daily

```
dpkg-buildpackage: info: source package capnet-assist
dpkg-buildpackage: info: source version 8.0.2-1+pkg42~daily~ubuntu26.04.1
dpkg-buildpackage: info: source distribution resolute
dpkg-buildpackage: info: source changed by Ryo Nakano <ryonakaknock3@gmail.com>
 dpkg-source -i -I.bzr -I.git --before-build .
dpkg-source: error: cannot parse Maintainer field value "elementary, Inc. <builds@elementary.io>"
dpkg-buildpackage: error: dpkg-source -i -I.bzr -I.git --before-build . subprocess failed with exit status 25
[Tue Apr 14 13:02:30 2026]
RUN: /usr/share/launchpad-buildd/bin/in-target scan-for-processes --backend=chroot --series=resolute --abi-tag=amd64 --isa-tag=amd64 RECIPEBRANCHBUILD-4030180
Scanning for processes to kill in build RECIPEBRANCHBUILD-4030180
```